### PR TITLE
Add GitHub markdown extraction utility and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
 # gh_md_extract
+
+A small Python package that provides both a library function and command line tool
+for extracting every Markdown file from a chosen subdirectory in a GitHub
+repository. The utility supports private repositories via GitHub personal access
+tokens (PATs) and can be embedded in other Python projects.
+
+## Installation
+
+```bash
+pip install .
+```
+
+To run the automated tests the optional "test" extras can be installed:
+
+```bash
+pip install .[test]
+```
+
+## Command line usage
+
+```bash
+gh-md-extract <repository> <subdirectory> <destination> [--token TOKEN] [--ref REF]
+```
+
+* `repository` – GitHub repository in the form `owner/name` or a HTTPS URL.
+* `subdirectory` – Directory under the repository to scan. Use `.` for the root.
+* `destination` – Local directory where downloaded Markdown files will be stored.
+* `--token` – Optional GitHub personal access token. Falls back to `GITHUB_TOKEN`.
+* `--ref` – Optional branch, tag, or commit SHA to download from.
+
+The command prints the local path of every Markdown file written to disk.
+
+## Library usage
+
+```python
+from gh_md_extract import extract_markdown_files
+
+files = extract_markdown_files(
+    "octocat/hello-world",
+    "docs",
+    "/tmp/output",
+    token="ghp_your_token_here",
+    ref="main",
+)
+
+for path in files:
+    print(path)
+```
+
+The function returns the list of :class:`pathlib.Path` objects pointing to the
+files that were written. Authentication is optional for public repositories but
+recommended to avoid hitting unauthenticated rate limits.
+
+## Development
+
+Run the unit test suite using:
+
+```bash
+pytest
+```
+

--- a/gh_md_extract/__init__.py
+++ b/gh_md_extract/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for extracting Markdown files from GitHub repositories."""
+
+from .extractor import GitHubAPIError, extract_markdown_files
+
+__all__ = ["GitHubAPIError", "extract_markdown_files"]

--- a/gh_md_extract/cli.py
+++ b/gh_md_extract/cli.py
@@ -1,0 +1,68 @@
+"""Command line entry point for :mod:`gh_md_extract`."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from .extractor import GitHubAPIError, extract_markdown_files
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download all Markdown files from a subdirectory in a GitHub repository"
+        )
+    )
+    parser.add_argument(
+        "repository",
+        help="GitHub repository in the form 'owner/name' or HTTPS URL",
+    )
+    parser.add_argument(
+        "subdirectory",
+        help="Repository subdirectory to scan (use '.' for the repository root)",
+    )
+    parser.add_argument(
+        "destination",
+        help="Local destination directory where Markdown files will be written",
+    )
+    parser.add_argument(
+        "--token",
+        help=(
+            "GitHub personal access token. If omitted the GITHUB_TOKEN environment "
+            "variable is used when available."
+        ),
+    )
+    parser.add_argument(
+        "--ref",
+        help="Git reference (branch, tag, or commit) to use. Defaults to default branch.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    token = args.token or os.getenv("GITHUB_TOKEN")
+
+    try:
+        files = extract_markdown_files(
+            args.repository,
+            args.subdirectory,
+            args.destination,
+            token=token,
+            ref=args.ref,
+        )
+    except (GitHubAPIError, ValueError) as exc:
+        parser.exit(1, f"Error: {exc}\n")
+
+    for path in files:
+        print(path)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for manual use
+    sys.exit(main())
+

--- a/gh_md_extract/extractor.py
+++ b/gh_md_extract/extractor.py
@@ -1,0 +1,278 @@
+"""Core extraction utilities for :mod:`gh_md_extract`."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Optional, Protocol
+from urllib import parse, request
+from urllib.parse import urlparse
+
+__all__ = ["GitHubAPIError", "extract_markdown_files"]
+
+
+class GitHubAPIError(RuntimeError):
+    """Raised when the GitHub API returns an error response."""
+
+
+class _ResponseProtocol(Protocol):
+    status_code: int
+    content: bytes
+
+    def json(self) -> object:
+        """Return the JSON-decoded payload."""
+
+
+class _SessionProtocol(Protocol):
+    def get(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> _ResponseProtocol:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class _RepoSpec:
+    owner: str
+    name: str
+
+    @property
+    def api_base(self) -> str:
+        return f"https://api.github.com/repos/{self.owner}/{self.name}"
+
+
+class _UrllibResponse:
+    def __init__(self, status_code: int, data: bytes):
+        self.status_code = status_code
+        self._data = data
+
+    @property
+    def content(self) -> bytes:
+        return self._data
+
+    def json(self) -> object:
+        try:
+            text = self._data.decode("utf-8")
+        except UnicodeDecodeError as exc:  # pragma: no cover - unexpected
+            raise GitHubAPIError("Unable to decode GitHub response as UTF-8") from exc
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - unexpected
+            raise GitHubAPIError("Unable to parse JSON payload from GitHub") from exc
+
+
+class _UrllibSession:
+    def get(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> _UrllibResponse:
+        if params:
+            query = parse.urlencode(params)
+            separator = "&" if parse.urlparse(url).query else "?"
+            url = f"{url}{separator}{query}"
+        req = request.Request(url, headers=headers or {}, method="GET")
+        with request.urlopen(req) as resp:  # type: ignore[call-arg]
+            data = resp.read()
+            status = getattr(resp, "status", 200)
+        return _UrllibResponse(status, data)
+
+    def close(self) -> None:  # pragma: no cover - nothing to clean up
+        return None
+
+
+def extract_markdown_files(
+    repository: str,
+    subdirectory: str,
+    destination: str | Path,
+    *,
+    token: str | None = None,
+    ref: str | None = None,
+    session: Optional[_SessionProtocol] = None,
+) -> list[Path]:
+    """Download all Markdown files from ``subdirectory`` within ``repository``.
+
+    Parameters
+    ----------
+    repository:
+        The repository identifier. Either ``"owner/name"`` or a GitHub HTTPS URL.
+    subdirectory:
+        The path to search within the repository. Use ``"."`` or ``""`` for the
+        repository root.
+    destination:
+        Directory where the Markdown files will be written. The directory is
+        created if it does not yet exist.
+    token:
+        Optional GitHub personal access token used for authenticating to private
+        repositories or to avoid rate limits.
+    ref:
+        Optional Git reference (branch, tag, or commit SHA). Defaults to the
+        repository's default branch.
+    session:
+        Optional HTTP session-like object with a :py:meth:`get` method returning a
+        response that implements :py:meth:`json` and the ``content`` attribute.
+
+    Returns
+    -------
+    list[Path]
+        A list of file paths that were written to the local filesystem.
+    """
+
+    repo_spec = _parse_repository(repository)
+    base_subdir = _normalise_subdirectory(subdirectory)
+    destination_path = Path(destination)
+    destination_path.mkdir(parents=True, exist_ok=True)
+
+    req_session = session or _UrllibSession()
+    headers = _build_headers(token)
+    params = {"ref": ref} if ref else None
+
+    collected: list[Path] = []
+    try:
+        for item in _iter_markdown_items(
+            req_session, repo_spec, base_subdir, headers, params
+        ):
+            relative_path = _relative_to_subdir(item.path, base_subdir)
+            local_path = destination_path.joinpath(Path(*relative_path.parts))
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            content = _download_file(req_session, item.url, headers, params)
+            local_path.write_bytes(content)
+            collected.append(local_path)
+    finally:
+        if session is None:
+            req_session.close()
+
+    return collected
+
+
+@dataclass(frozen=True)
+class _ContentItem:
+    path: PurePosixPath
+    url: str
+
+
+def _build_headers(token: str | None) -> dict[str, str]:
+    headers = {"User-Agent": "gh-md-extract"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _download_file(
+    session: _SessionProtocol,
+    url: str,
+    headers: dict[str, str],
+    params: Optional[dict[str, str]] = None,
+) -> bytes:
+    raw_headers = {**headers, "Accept": "application/vnd.github.raw"}
+    response = session.get(url, headers=raw_headers, params=params)
+    if response.status_code != 200:
+        raise GitHubAPIError(
+            f"GitHub returned status {response.status_code} while downloading {url}"
+        )
+    return response.content
+
+
+def _iter_markdown_items(
+    session: _SessionProtocol,
+    repo_spec: _RepoSpec,
+    subdirectory: str,
+    headers: dict[str, str],
+    params: Optional[dict[str, str]],
+) -> Iterable[_ContentItem]:
+    queue = [_as_posix(subdirectory)]
+    base_url = repo_spec.api_base + "/contents"
+
+    while queue:
+        current = queue.pop()
+        url = base_url if current == "" else f"{base_url}/{current}"
+        response = session.get(url, headers=headers, params=params)
+        if response.status_code == 404:
+            raise GitHubAPIError(
+                f"Path '{current or '.'}' was not found in repository"
+            )
+        if response.status_code != 200:
+            raise GitHubAPIError(
+                f"GitHub returned status {response.status_code} for {url}"
+            )
+
+        payload = response.json()
+        if isinstance(payload, dict) and payload.get("type") == "file":
+            if _is_markdown_file(payload.get("name", "")):
+                yield _ContentItem(PurePosixPath(payload["path"]), payload["url"])
+            continue
+
+        if not isinstance(payload, list):
+            raise GitHubAPIError("Unexpected response format from GitHub API")
+
+        for item in payload:
+            item_type = item.get("type")
+            if item_type == "dir":
+                queue.append(item["path"])
+            elif item_type == "file" and _is_markdown_file(item.get("name", "")):
+                yield _ContentItem(PurePosixPath(item["path"]), item["url"])
+
+
+def _is_markdown_file(filename: str) -> bool:
+    lower = filename.lower()
+    return lower.endswith(".md") or lower.endswith(".markdown")
+
+
+def _relative_to_subdir(path: PurePosixPath, subdirectory: str) -> PurePosixPath:
+    base = PurePosixPath(_as_posix(subdirectory))
+    if str(base) in ("", "."):
+        return path
+    try:
+        return path.relative_to(base)
+    except ValueError as exc:  # pragma: no cover - safeguard, should not occur
+        raise GitHubAPIError(
+            f"Unable to compute relative path for '{path}' within '{base}'"
+        ) from exc
+
+
+def _normalise_subdirectory(subdirectory: str) -> str:
+    as_posix = _as_posix(subdirectory)
+    if as_posix in ("", "."):
+        return ""
+    return as_posix
+
+
+def _as_posix(path: str) -> str:
+    return str(PurePosixPath(path.strip().strip("/"))) if path else ""
+
+
+def _parse_repository(repository: str) -> _RepoSpec:
+    repository = repository.strip()
+    if not repository:
+        raise ValueError("Repository must be provided")
+
+    if repository.startswith("http://") or repository.startswith("https://"):
+        parsed = urlparse(repository)
+        path = parsed.path.rstrip("/")
+        parts = [part for part in path.split("/") if part]
+        if len(parts) < 2:
+            raise ValueError(
+                "Repository URL must be in the form https://github.com/owner/name"
+            )
+        owner, name = parts[0], parts[1]
+    else:
+        parts = [part for part in repository.split("/") if part]
+        if len(parts) != 2:
+            raise ValueError(
+                "Repository must be provided as 'owner/name' or a GitHub URL"
+            )
+        owner, name = parts
+
+    if name.endswith(".git"):
+        name = name[:-4]
+
+    return _RepoSpec(owner=owner, name=name)
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gh-md-extract"
+version = "0.1.0"
+description = "Command line tool and library to extract Markdown files from GitHub repositories."
+readme = "README.md"
+authors = [{name = "Your Name"}]
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+gh-md-extract = "gh_md_extract.cli:main"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["."]
+

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Tuple
+
+import pytest
+
+from gh_md_extract import GitHubAPIError, extract_markdown_files
+
+
+@dataclass
+class _FakeResponse:
+    status_code: int
+    _json: object | None = None
+    content: bytes = b""
+
+    def json(self):
+        return self._json
+
+
+class _FakeSession:
+    def __init__(self, responses: Dict[Tuple[str, Tuple[Tuple[str, str], ...]], _FakeResponse]):
+        self._responses = responses
+        self.calls: list[Tuple[str, dict | None, dict | None]] = []
+
+    def get(self, url: str, headers: dict | None = None, params: dict | None = None):
+        params_tuple = tuple(sorted((params or {}).items()))
+        key = (url, params_tuple)
+        self.calls.append((url, headers, params))
+        try:
+            return self._responses[key]
+        except KeyError as exc:  # pragma: no cover - protective assertion
+            raise AssertionError(f"Unexpected request for {url} with {params}") from exc
+
+    def close(self):
+        pass
+
+
+def _build_key(url: str, params: dict | None = None) -> Tuple[str, Tuple[Tuple[str, str], ...]]:
+    params_tuple: Tuple[Tuple[str, str], ...] = tuple(sorted((params or {}).items()))
+    return url, params_tuple
+
+
+def test_extract_markdown_files(tmp_path: Path) -> None:
+    repo_api = "https://api.github.com/repos/octocat/hello-world"
+    responses_map = {
+        _build_key(f"{repo_api}/contents/docs", {"ref": "main"}): _FakeResponse(
+            200,
+            [
+                {
+                    "name": "README.md",
+                    "path": "docs/README.md",
+                    "type": "file",
+                    "url": f"{repo_api}/contents/docs/README.md",
+                },
+                {
+                    "name": "guides",
+                    "path": "docs/guides",
+                    "type": "dir",
+                },
+                {
+                    "name": "image.png",
+                    "path": "docs/image.png",
+                    "type": "file",
+                    "url": f"{repo_api}/contents/docs/image.png",
+                },
+            ],
+        ),
+        _build_key(f"{repo_api}/contents/docs/guides", {"ref": "main"}): _FakeResponse(
+            200,
+            [
+                {
+                    "name": "setup.md",
+                    "path": "docs/guides/setup.md",
+                    "type": "file",
+                    "url": f"{repo_api}/contents/docs/guides/setup.md",
+                }
+            ],
+        ),
+        _build_key(f"{repo_api}/contents/docs/README.md", {"ref": "main"}): _FakeResponse(
+            200,
+            content=b"Root docs",
+        ),
+        _build_key(
+            f"{repo_api}/contents/docs/guides/setup.md", {"ref": "main"}
+        ): _FakeResponse(200, content=b"Setup guide"),
+    }
+
+    fake_session = _FakeSession(responses_map)
+
+    files = extract_markdown_files(
+        "octocat/hello-world",
+        "docs",
+        tmp_path,
+        token="token",
+        ref="main",
+        session=fake_session,
+    )
+
+    expected = {tmp_path / "README.md", tmp_path / "guides" / "setup.md"}
+    assert set(files) == expected
+    assert (tmp_path / "README.md").read_text() == "Root docs"
+    assert (tmp_path / "guides" / "setup.md").read_text() == "Setup guide"
+    assert not (tmp_path / "image.png").exists()
+
+
+def test_missing_directory_raises_error(tmp_path: Path) -> None:
+    repo_api = "https://api.github.com/repos/octocat/hello-world"
+    responses_map = {
+        _build_key(f"{repo_api}/contents/docs", None): _FakeResponse(404, {"message": "Not Found"})
+    }
+    fake_session = _FakeSession(responses_map)
+
+    with pytest.raises(GitHubAPIError):
+        extract_markdown_files("octocat/hello-world", "docs", tmp_path, session=fake_session)
+
+
+def test_invalid_repository_string(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        extract_markdown_files("invalid-repo", "docs", tmp_path)
+


### PR DESCRIPTION
## Summary
- add a reusable Python module and CLI that download Markdown files from a GitHub repository subdirectory
- document installation, CLI usage, and library usage in the README
- configure packaging metadata, tests, and ignore Python cache artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17d4923cc8330abe6466732aa2722